### PR TITLE
add property main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "PUBLIC DOMAIN (UNLICENSED)",
   "repository": "shannonmoeller/reset-css",
   "style": "reset.css",
+  "main": "reset.css",
   "files": [
     "reset.css",
     "reset.less",


### PR DESCRIPTION
Main is the main file, when using imports in Webpack for example
