### PR TITLE
Rename license in Package JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "authors": [
     "Eric Meyer"
   ],
-  "license": "PUBLIC DOMAIN (UNLICENSED)",
+  "license": "Unlicense",
   "repository": "shannonmoeller/reset-css",
   "style": "reset.css",
   "main": "reset.css",


### PR DESCRIPTION
Rename license in `package.json` to be compliant with the SPDX License List. This helps legal Tooling around licenses.