### PR TITLE
Reset <menu> list style

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -9,7 +9,7 @@ a, abbr, acronym, address, big, cite, code,
 del, dfn, em, img, ins, kbd, q, s, samp,
 small, strike, strong, sub, sup, tt, var,
 b, u, i, center,
-dl, dt, dd, ol, ul, li,
+dl, dt, dd, menu, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
 article, aside, canvas, details, embed,
@@ -35,7 +35,7 @@ footer, header, hgroup, main, menu, nav, section {
 body {
 	line-height: 1;
 }
-ol, ul {
+menu, ol, ul {
 	list-style: none;
 }
 blockquote, q {


### PR DESCRIPTION
<menu> is displayed as an unordered list on newer browser. Here we reset them as well.